### PR TITLE
fix invalid option message, add option to README, ignore tmenu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*.o
 /*_test
+/tmenu

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ If you want to change compilation and linking flags, modify
 the options in separate files causes `make` to recompile the program if
 options change.
 
+# Options
+
+- `-l LINES`: Set the height of the completion list in lines to LINES.  Defaults to 3.
+- `-p PROMPT`: Set the prompt shown to the user to PROMPT.  Defaults to `>>`.
+
 # Key Bindings
 
 - `Return`, `C-j`: Output the currently selected item on stdout and exit.

--- a/main.c
+++ b/main.c
@@ -232,7 +232,6 @@ int main(int argc, char** argv) {
             Menu.set_height(menu, atoi(optarg));
             break;
          default:
-            fprintf(stderr, "%s: unknown option '%c'\n", argv[0], opt);
             exit(EXIT_FAILURE);
       }
    }


### PR DESCRIPTION
The error message (second output line) for unknown options are redundant and incorrect.

```
$ ./tmenu -x
./tmenu: invalid option -- 'x'
./tmenu: unknown option '?'
```

It should be `optopt` in line 235, but since `getopt` already prints out error message (first output line), so I just removed it.
