### PR TITLE
Fix "git branches" snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ options change.
 Add an git alias with the following command to switch git branches using
 `tmenu`:
 
-    git alias br "!git ls-remote -h . | awk '{print $NF}' | tmenu | xargs git checkout"
+    git alias br "!git ls-remote -h . | awk '{print(substr($NF, 12))}' | tmenu | xargs git checkout"
 
 Then use `git br` to interactively switch the git branch.
 


### PR DESCRIPTION
The previous snippet was checking out the refs and thus was resulting in a "detached HEAD state". This fix gets rid of the `refs/heads/` prefix".
